### PR TITLE
ft #158787482 : Improve gradle build speeds by caching 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,7 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+org.gradle.daemon=true
+org.gradle.caching=true
+org.gradle.configureondemand=true


### PR DESCRIPTION
#### What does this PR do?
This PR improves the gradle build speeds by implementing the use of cache

#### Description of Task to be completed?
Initially the gradle build speeds were slow and this was because cacheing had not been enabled.
This PR delivers the use of cache to implement the build speeds.
By using org.gradle.daemon we make reuse of things in subsequent builds, by using org.gradle.configureondemand we only configure modules necessary for the application and 
org.gradle.caching used to enable general cacheing 

#### SCREENSHOTS
<img width="434" alt="screen shot 2018-08-20 at 19 41 24" src="https://user-images.githubusercontent.com/17830204/44354992-fd441980-a4b3-11e8-88f9-465b6cbe2a43.png">
Before cacheing

<img width="431" alt="screen shot 2018-08-20 at 19 42 16" src="https://user-images.githubusercontent.com/17830204/44355027-12b94380-a4b4-11e8-9f3b-6b130e1a9a33.png">
After Cacheing

#### How should this be manually tested?
1. Clone the repository onto your machine and build the app. 
2. Run `./gradlew --build-cache clean assemble ` and take notice of the build speeds
3. Run the command again and notice the build speeds when cacheing has been applied

#### Background context
NONE

#### What are the relevant pivotal tracker stories?
[Delivers #158787482]