### PR TITLE
ft #158790540: App distribution with Beta by Crashlytics

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,19 @@
+buildscript {
+    repositories {
+        maven { url 'https://maven.fabric.io/public' }
+    }
+
+    dependencies {
+        classpath 'io.fabric.tools:gradle:1.+'
+    }
+}
 apply plugin: 'com.android.application'
+apply plugin: 'io.fabric'
+
+repositories {
+    maven { url 'https://maven.fabric.io/public' }
+}
+
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
@@ -39,4 +54,7 @@ dependencies {
     implementation "com.squareup.picasso:picasso:$rootProject.picasoVersion"
     implementation "com.squareup.retrofit2:retrofit:$rootProject.retrofitVersion"
     implementation "com.squareup.retrofit2:converter-gson:$rootProject.retrofitVersion"
+    compile('com.crashlytics.sdk.android:crashlytics:2.9.4@aar') {
+        transitive = true;
+    }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,9 @@
             android:name=".DetailActivity"
             android:label="@string/app_intro"
             />
+        <meta-data
+            android:name="io.fabric.ApiKey"
+            android:value="80231a7745ab1acb04d4440829048abe3a2362ca" />
     </application>
   
 </manifest>

--- a/app/src/main/java/com/example/asiimwebenard/javadevelopersinnairobi/MainActivity.java
+++ b/app/src/main/java/com/example/asiimwebenard/javadevelopersinnairobi/MainActivity.java
@@ -13,12 +13,14 @@ import android.support.v7.widget.RecyclerView;
 import android.util.Log;
 import android.view.View;
 
+import com.crashlytics.android.Crashlytics;
 import com.example.asiimwebenard.javadevelopersinnairobi.adapter.GithubUserAdapter;
 import com.example.asiimwebenard.javadevelopersinnairobi.model.GithubUsers;
 import com.example.asiimwebenard.javadevelopersinnairobi.presenter.GithubPresenter;
 import com.example.asiimwebenard.javadevelopersinnairobi.util.NetworkConnection;
 import com.example.asiimwebenard.javadevelopersinnairobi.views.GithubUserView;
 
+import io.fabric.sdk.android.Fabric;
 import java.util.List;
 
 
@@ -32,6 +34,7 @@ public class MainActivity extends AppCompatActivity implements GithubUserView {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        Fabric.with(this, new Crashlytics());
         setContentView(R.layout.activity_main);
         recyclerView = findViewById(R.id.recycler_view);
         layoutManager = new GridLayoutManager(this, 2);


### PR DESCRIPTION
#### What does this PR do?
This PR integrates app distribution with Beta by Crashlytics

#### Description of Task to be completed?
Initially, it was impossible to get users to act as beta testers for the application, by integrating Fabric and accepting Crashlytics into the application, it is now possible to distribute the application to beta testers, get Stat reports, crash reports and monitor general use of the application.

#### SCREENSHOTS
![screen shot 2018-08-24 at 17 11 30](https://user-images.githubusercontent.com/17830204/44590853-cd06be80-a7c4-11e8-8719-6ca406583624.png)
The dashboard at fabric.io
![screen shot 2018-08-24 at 17 41 12 2](https://user-images.githubusercontent.com/17830204/44590951-00e1e400-a7c5-11e8-9b32-9fa01958da4f.png)
The panel in Android studio

#### How should this be manually tested?
1. Clone the repository onto your local machine
2. Three files were changed to include the CrashAnalytics ie. 
```
app/build.gradle, 
app/src/main/AndroidManifest.xml
app/src/main/java/com/example/asiimwebenard/javadevelopersinnairobi/MainActivity.java
```
#### Background context
NONE

#### What are the relevant pivotal tracker stories?
[Delivers #158790540]